### PR TITLE
removed pprint from requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ parso==0.1.0
 pexpect==4.2.1
 pickleshare==0.7.4
 Pillow==4.3.0
-pprint==0.1
 prompt-toolkit==1.0.15
 psycopg2==2.7.3.2
 ptyprocess==0.5.2


### PR DESCRIPTION
During the build process, pprint causes an error, since the package has been included into the python standard library. Taking it out prevents the error and maintains current functionality.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. -->

## Pls do 
- [x] Tested and working
- [x] Unit tests

## Test plan
<!-- Describe how you can reproduce the fact that your feature works -->

